### PR TITLE
Bugfix in mailbox::getMessage:

### DIFF
--- a/src/mailbox.php
+++ b/src/mailbox.php
@@ -150,7 +150,7 @@ class mailbox {
         $headers = ['message-id', 'uid', 'references'];
         $headers = array_unique(array_merge($headers, $add_headers));
         
-        $result = $this->rcube_imap_generic->fetchHeaders($this->mailboxname, $uid, true, $bodystr, $add_headers);
+        $result = $this->rcube_imap_generic->fetchHeaders($this->mailboxname, $uid, true, $bodystr, $headers);
         
         $rcube_message_header = reset($result);
         


### PR DESCRIPTION
fetch basic headers + additional headers not only additional headers